### PR TITLE
Reload music library on SIGHUP

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -52,7 +52,7 @@ func run() error {
 	}
 
 	log.Println("Loading library")
-	library, err := musiclib.NewLibrary(context.Background(), rootPaths)
+	library, err := musiclib.NewIndexedLibrary(context.Background(), rootPaths)
 	if err != nil {
 		return fmt.Errorf("failed to init library: %v", err)
 	}
@@ -80,9 +80,14 @@ func run() error {
 	return nil
 }
 
+type library interface {
+	Browse(ctx context.Context, browseURI string, opts musiclib.BrowseOptions) ([]*musiclib.BrowseItem, error)
+	Media(ctx context.Context, uri string, opts musiclib.BrowseOptions) ([]string, error)
+}
+
 type server struct {
 	mlibgrpc.UnimplementedMusicLibraryServer
-	library *musiclib.Library
+	library library
 }
 
 func (s *server) Browse(ctx context.Context, in *mlibgrpc.BrowseRequest) (*mlibgrpc.BrowseResponse, error) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/mctofu/musiclib"
@@ -18,13 +19,16 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatalf("Error occurred: %v", err)
+		log.Fatalf("Error occurred: %v\n", err)
 	}
 }
 
 func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+
+	reload := make(chan os.Signal)
+	signal.Notify(reload, syscall.SIGHUP)
 
 	rootPathSetting, _ := os.LookupEnv("MUSICLIB_ROOT_PATHS")
 	listenAddrSetting, _ := os.LookupEnv("MUSICLIB_LISTEN_ADDR")
@@ -64,10 +68,22 @@ func run() error {
 		})
 
 	go func() {
-		<-ctx.Done()
-		log.Println("Stopping")
-		s.GracefulStop()
-		log.Println("Stopped")
+		for {
+			select {
+			case <-reload:
+				log.Println("Reloading library")
+				if err := library.Load(ctx); err != nil {
+					log.Printf("Failed to reload library: %v\n", err)
+				} else {
+					log.Println("Reloaded library")
+				}
+			case <-ctx.Done():
+				log.Println("Stopping")
+				s.GracefulStop()
+				log.Println("Stopped")
+				return
+			}
+		}
 	}()
 
 	log.Println("Starting server")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -52,8 +52,8 @@ func run() error {
 	}
 
 	log.Println("Loading library")
-	library, err := musiclib.NewIndexedLibrary(context.Background(), rootPaths)
-	if err != nil {
+	library := musiclib.NewReloadableLibrary(rootPaths)
+	if err := library.Load(context.Background()); err != nil {
 		return fmt.Errorf("failed to init library: %v", err)
 	}
 	log.Println("Loaded library")

--- a/library.go
+++ b/library.go
@@ -58,9 +58,9 @@ type IndexedLibrary struct {
 }
 
 func NewIndexedLibrary(ctx context.Context, rootPaths []string) (*IndexedLibrary, error) {
-	files, err := ScanRoots(rootPaths)
+	files, err := ScanRoots(ctx, rootPaths)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to scan files: %v", err)
 	}
 	log.Println("Scanned root paths")
 

--- a/library.go
+++ b/library.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type Library struct {
+type IndexedLibrary struct {
 	RootPaths    []string
 	AlbumArtists *MetadataIndex
 	Files        *FileIndex
@@ -17,7 +17,7 @@ type Library struct {
 	ModifyDates  *MetadataIndex
 }
 
-func NewLibrary(ctx context.Context, rootPaths []string) (*Library, error) {
+func NewIndexedLibrary(ctx context.Context, rootPaths []string) (*IndexedLibrary, error) {
 	files, err := ScanRoots(rootPaths)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func NewLibrary(ctx context.Context, rootPaths []string) (*Library, error) {
 	}
 	log.Println("Indexed modified dates")
 
-	return &Library{
+	return &IndexedLibrary{
 		RootPaths:    rootPaths,
 		AlbumArtists: artistAlbums,
 		Files:        filesIndex,
@@ -64,7 +64,7 @@ func NewLibrary(ctx context.Context, rootPaths []string) (*Library, error) {
 	}, nil
 }
 
-func (l *Library) Browse(ctx context.Context, browseURI string, opts BrowseOptions) ([]*BrowseItem, error) {
+func (l *IndexedLibrary) Browse(ctx context.Context, browseURI string, opts BrowseOptions) ([]*BrowseItem, error) {
 	index, err := l.index(opts.BrowseType)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func (l *Library) Browse(ctx context.Context, browseURI string, opts BrowseOptio
 	return filter(node, node.Children, opts.TextFilter)
 }
 
-func (l *Library) Media(ctx context.Context, uri string, opts BrowseOptions) ([]string, error) {
+func (l *IndexedLibrary) Media(ctx context.Context, uri string, opts BrowseOptions) ([]string, error) {
 	index, err := l.index(opts.BrowseType)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (l *Library) Media(ctx context.Context, uri string, opts BrowseOptions) ([]
 	return filterLeaves(node, opts.TextFilter)
 }
 
-func (l *Library) index(t BrowseType) (Index, error) {
+func (l *IndexedLibrary) index(t BrowseType) (Index, error) {
 	switch t {
 	case BrowseTypeFile:
 		return l.Files, nil

--- a/metadata.go
+++ b/metadata.go
@@ -34,6 +34,10 @@ func (a *MetadataIndex) Node(ctx context.Context, uri string) (*Node, error) {
 
 func (a *MetadataIndex) Index(ctx context.Context, files *Files) error {
 	if err := files.WalkFiles(func(dir *PathMeta, file *PathMeta) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		if file.Metadata == nil {
 			log.Printf("No metadata for: %s\n", file.Path)
 			return nil

--- a/scan.go
+++ b/scan.go
@@ -1,6 +1,7 @@
 package musiclib
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -82,10 +83,10 @@ func (f *PathMeta) walkChildren(walkFn WalkFunc) error {
 	return nil
 }
 
-func ScanRoots(roots []string) (*Files, error) {
+func ScanRoots(ctx context.Context, roots []string) (*Files, error) {
 	var rootMetas []PathMeta
 	for _, root := range roots {
-		meta, err := scanDir(path.Base(root), root)
+		meta, err := scanDir(ctx, path.Base(root), root)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +100,7 @@ func ScanRoots(roots []string) (*Files, error) {
 	}, nil
 }
 
-func scanDir(name string, dir string) (*PathMeta, error) {
+func scanDir(ctx context.Context, name string, dir string) (*PathMeta, error) {
 	meta := &PathMeta{
 		Name: name,
 		Path: dir,
@@ -114,8 +115,12 @@ func scanDir(name string, dir string) (*PathMeta, error) {
 	}
 
 	for _, file := range files {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		if file.IsDir() {
-			child, err := scanDir(file.Name(), path.Join(dir, file.Name()))
+			child, err := scanDir(ctx, file.Name(), path.Join(dir, file.Name()))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This triggers a background reload and swap of the music library when the process receives SIGHUP (`kill -HUP pid`).

This starts to clear the way for auto reload on filesystem changes in https://github.com/mctofu/musiclib/issues/14. It could also be combine with an external filesystem monitor like systemd to trigger the SIGHUP.